### PR TITLE
Enable to run multiple models

### DIFF
--- a/ProxyFilePaths.config
+++ b/ProxyFilePaths.config
@@ -1,0 +1,7 @@
+#PoissonProcess
+objectIDProxyFile=/statistics/poisson_ids.json
+poissonProcessProxyFile=/statistics/poisson_stats.json
+
+#PointProcess
+objectIDProxyFile=/statistics/point_ids.json
+pointProcessProxyFile=/statistics/point_stats.json

--- a/doc/run.md
+++ b/doc/run.md
@@ -128,7 +128,49 @@ user@apollo5$ cd ${SOCIALCUBEPATH}/src
 user@apollo5$ make
 ```
 
-It will generate an executable called __socialcube__. Run the following command to start simulation:
+It will generate an executable called __socialcube__. 
+
+Under the root folder, there is a configure file called _ProxyFilePaths.config_, which is used for setting the types of models and their corresponding proxy files.
+
+In _ProxyFilePaths.config_, use `#ModelName` to start a new model configuration. Lines following a `#ModelName` should be in the form of `ProxyFileName=ProxyFilePath`. The configuration of a model is ended with a line break.
+
+For example, a valid _ProxyFilePaths.config_ can be:
+
+```
+#PoissonProcess
+objectIDProxyFile=/statistics/poisson_ids.json
+poissonProcessProxyFile=/statistics/poisson_stats.json
+
+#PointProcess
+objectIDProxyFile=/statistics/point_ids.json
+pointProcessProxyFile=/statistics/point_stats.json
+```
+
+In the first line, it starts a new model called _PoissonProcess_. The second line sets the path of the _objectIDProxyFile_ of this _PoissonProcess_ to be _${SOCIALSIMPATH}/statistics/poisson_ids.json_. And the third line set  _poissonProcessProxyFile_ to be _/statistics/poisson_stats.json_. Those unspecified proxy file paths will remain default. 
+
+The configruations of two models are seperated by a line break. The second model in this config file is _PointProcess_. 
+
+Currently we support model types including:
+
+- PointProcess
+- PoissionProcess
+- SimpleModel
+
+So please make sure the model types specified in _ProxyFilePaths.config_ belong to the three.
+
+And the file paths that can be set include:
+
+- userIDProxyFile
+- objectIDProxyFile
+- hourlyActionRateFile
+- objectPreferenceProxyFile
+- pointProcessProxyFile
+- poissonProcessProxyFile
+
+For unset file paths, this framework will use default paths to find the corresponding files. (see __${SOCIALSIMPATH}/src/ArgParser/ArgParser.cpp__  to check the default file paths)
+
+Run the following command to start simulation:
+
 ```
 user@apollo5$ ./socialcube --show_profile --show_event -s 2018-02-01T00:00:00Z -e "2018-02-02T00:00:00Z"
 ```

--- a/src/AgentBuilder/AgentBuilder.hpp
+++ b/src/AgentBuilder/AgentBuilder.hpp
@@ -8,10 +8,10 @@
 #include "Log/Log.hpp"
 
 template<class TUserAgent, class TObjectAgent>
-class AgentBuilder {
+class AgentBuilder{
 
 private:
-    const StatisticProxy& m_statProxy;
+    StatisticProxy& m_statProxy;
 
     std::vector<std::shared_ptr<TUserAgent>> m_userAgents; 
 
@@ -28,6 +28,8 @@ public:
     ~AgentBuilder();
 
     void build();
+
+    void setFilePath(const std::string fileName, const std::string filePath);
 
     std::vector<std::shared_ptr<TUserAgent>>& getUserAgentList();
 

--- a/src/AgentBuilder/AgentBuilder.tpp
+++ b/src/AgentBuilder/AgentBuilder.tpp
@@ -13,7 +13,27 @@ AgentBuilder<TUserAgent, TObjectAgent>::~AgentBuilder() {
 }
 
 template<class TUserAgent, class TObjectAgent>
+void AgentBuilder<TUserAgent, TObjectAgent>::setFilePath(const std::string fileName, const std::string filePath) {
+    if (fileName == "userIDProxyFile") {
+        m_statProxy.setUserIDProxyFilePath(filePath);
+    } else if (fileName == "objectIDProxyFile") {
+        m_statProxy.setObjectIDProxyFilePath(filePath);
+    } else if (fileName == "hourlyActionRateFile") {
+        m_statProxy.setHourlyActionRateProxyFilePath(filePath);
+    } else if (fileName == "objectPreferenceProxyFile") {
+        std::cout << "set objectPreferenceProxyFile OK" << std::endl;
+        m_statProxy.setObjectPreferenceProxyFilePath(filePath);
+    } else if (fileName == "pointProcessProxyFile") {
+        m_statProxy.setPointProcessProxyFilePath(filePath);
+    } else if (fileName == "poissonProcessProxyFile") {
+        m_statProxy.setPoissonProcessProxyFilePath(filePath);
+    }
+}
+
+template<class TUserAgent, class TObjectAgent>
 void AgentBuilder<TUserAgent, TObjectAgent>::build() {
+    m_statProxy.startParsing();
+    std::cout << "finish startParsing" << std::endl;
     buildUsers();
     buildObjects();
     DBG(LOGD(TAG, "Agent Builder generates "+stringfy(m_userAgents.size())+" user agents");)
@@ -33,6 +53,7 @@ std::vector<std::shared_ptr<TObjectAgent>>& AgentBuilder<TUserAgent, TObjectAgen
 template<class TUserAgent, class TObjectAgent>
 void AgentBuilder<TUserAgent, TObjectAgent>::buildUsers() {
     const std::vector<std::string>& userIDs = m_statProxy.getUserIDs();
+
     for(auto& userID : userIDs) {
         std::shared_ptr<TUserAgent> agent(new TUserAgent(userID));
         m_userAgents.push_back(move(agent));
@@ -41,9 +62,13 @@ void AgentBuilder<TUserAgent, TObjectAgent>::buildUsers() {
 
 template<class TUserAgent, class TObjectAgent>
 void AgentBuilder<TUserAgent, TObjectAgent>::buildObjects() {
+    std::cout << "buildObjects" << std::endl;
     const std::vector<std::string>& objectIDs = m_statProxy.getObjectIDs();
+    std::cout << "m_statProxy.getObjectIDs() OK, length = " << objectIDs.size() << std::endl;
+
     for(auto& objectID : objectIDs) {
         std::shared_ptr<TObjectAgent> agent(new TObjectAgent(objectID));
         m_objectAgents.push_back(move(agent));
     }
+    std::cout << "buildObjects OK" << std::endl;
 }

--- a/src/AgentBuilder/AgentBuilder.tpp
+++ b/src/AgentBuilder/AgentBuilder.tpp
@@ -21,7 +21,6 @@ void AgentBuilder<TUserAgent, TObjectAgent>::setFilePath(const std::string fileN
     } else if (fileName == "hourlyActionRateFile") {
         m_statProxy.setHourlyActionRateProxyFilePath(filePath);
     } else if (fileName == "objectPreferenceProxyFile") {
-        std::cout << "set objectPreferenceProxyFile OK" << std::endl;
         m_statProxy.setObjectPreferenceProxyFilePath(filePath);
     } else if (fileName == "pointProcessProxyFile") {
         m_statProxy.setPointProcessProxyFilePath(filePath);
@@ -33,7 +32,6 @@ void AgentBuilder<TUserAgent, TObjectAgent>::setFilePath(const std::string fileN
 template<class TUserAgent, class TObjectAgent>
 void AgentBuilder<TUserAgent, TObjectAgent>::build() {
     m_statProxy.startParsing();
-    std::cout << "finish startParsing" << std::endl;
     buildUsers();
     buildObjects();
     DBG(LOGD(TAG, "Agent Builder generates "+stringfy(m_userAgents.size())+" user agents");)
@@ -62,13 +60,10 @@ void AgentBuilder<TUserAgent, TObjectAgent>::buildUsers() {
 
 template<class TUserAgent, class TObjectAgent>
 void AgentBuilder<TUserAgent, TObjectAgent>::buildObjects() {
-    std::cout << "buildObjects" << std::endl;
     const std::vector<std::string>& objectIDs = m_statProxy.getObjectIDs();
-    std::cout << "m_statProxy.getObjectIDs() OK, length = " << objectIDs.size() << std::endl;
 
     for(auto& objectID : objectIDs) {
         std::shared_ptr<TObjectAgent> agent(new TObjectAgent(objectID));
         m_objectAgents.push_back(move(agent));
     }
-    std::cout << "buildObjects OK" << std::endl;
 }

--- a/src/ArgParser/ArgParser.cpp
+++ b/src/ArgParser/ArgParser.cpp
@@ -105,9 +105,9 @@ void ArgParser::initSocialCubeArgFromCLI(int argc, const char* argv[]) {
                 time (&rawtime);
                 timeinfo = localtime(&rawtime);
 
-                strftime(buffer,sizeof(buffer),"%d-%m-%Y_%I:%M:%S",timeinfo);
+                strftime(buffer,sizeof(buffer),"%d-%m-%Y_%H:%M:%S",timeinfo);
                 std::string str(buffer);
-                event_file = socialcubePath + "/events_" + str + ".txt";
+                event_file = socialcubePath + "/events" + str + ".txt";
             }
 
             if (result.count("init_file")) { 

--- a/src/ArgParser/ArgParser.cpp
+++ b/src/ArgParser/ArgParser.cpp
@@ -1,4 +1,7 @@
 #include "ArgParser.hpp"
+#include <iostream>
+#include <iomanip>
+#include <ctime>
 
 using namespace std;
 
@@ -95,7 +98,16 @@ void ArgParser::initSocialCubeArgFromCLI(int argc, const char* argv[]) {
                 event_file = result["event_file"].as<string>();
             } else {
                 const string socialcubePath = (getenv("SOCIALCUBEPATH"));
-                event_file = socialcubePath + string("/events.txt");
+                time_t rawtime;
+                struct tm * timeinfo;
+                char buffer[80];
+
+                time (&rawtime);
+                timeinfo = localtime(&rawtime);
+
+                strftime(buffer,sizeof(buffer),"%d-%m-%Y_%I:%M:%S",timeinfo);
+                std::string str(buffer);
+                event_file = socialcubePath + "/events_" + str + ".txt";
             }
 
             if (result.count("init_file")) { 

--- a/src/EventManager/EventManager.cpp
+++ b/src/EventManager/EventManager.cpp
@@ -42,8 +42,7 @@ void EventManager::start() {
     DBG(LOGP(TAG, "Event Storage: "+m_eventFileName);)
     DBG(LOGP(TAG, "Event Show Status: "+stringfy(m_eventOn));)
     DBG(LOGP(TAG, "*************************** Simulator Configuration ***************************\n\n", false);)
-
-    m_eventFile.open(m_eventFileName.c_str()); 
+    m_eventFile.open(m_eventFileName.c_str(), std::ofstream::app);
 }
 
 void EventManager::end() {

--- a/src/StatisticProxy/PointProcessProxy/PointProcessProxy.cpp
+++ b/src/StatisticProxy/PointProcessProxy/PointProcessProxy.cpp
@@ -5,7 +5,8 @@ DBG(static const string tag="PointProcessProxy";)
 using namespace std;
 
 PointProcessProxy::PointProcessProxy(const string& file) throw() {
-    try {
+    std::cout << file << std::endl;
+	try {
         m_pointProcessStatisticsFile.open (file);
     } catch (exception &e) {
         PointProcessProxyException p_e;

--- a/src/StatisticProxy/StatisticProxy.cpp
+++ b/src/StatisticProxy/StatisticProxy.cpp
@@ -1,4 +1,5 @@
 #include "StatisticProxy.hpp"
+#include <fstream>
 
 using namespace std;
 
@@ -11,27 +12,42 @@ StatisticProxy::StatisticProxy() {
 
     initProxySourceFile();
 
+    return;
+}
+
+StatisticProxy::~StatisticProxy() {
+    return;
+}
+
+void StatisticProxy::startParsing() {
+    std::cout << "m_defaultUserIDProxyFile = " << m_defaultUserIDProxyFile << std::endl;
+    std::cout << "m_defaultObjectIDProxyFile = " << m_defaultObjectIDProxyFile << std::endl;
+    std::cout << "m_defaultPointProcessProxyFile = " << m_defaultPointProcessProxyFile << std::endl;
+    std::cout << "m_defaultPoissonProcessProxyFile = " << m_defaultPoissonProcessProxyFile << std::endl;
+
     m_userIDProxy.reset(new ClusteredUserIDProxy(m_defaultUserIDProxyFile));
     m_objectIDProxy.reset(new ObjectIDProxy(m_defaultObjectIDProxyFile));
     m_objectPreferenceProxy.reset(new ObjectPreferenceProxy(m_defaultObjectPreferenceProxyFile));
     m_hourlyActionRateProxy.reset(new HourlyActionRateProxy(m_defaultHourlyActionRateProxyFile));
     m_typeDistributionProxy.reset(new TypeDistributionProxy(m_defaultTypeDistributionProxyFile));
-    m_pointProcessProxy.reset(new PointProcessProxy(m_defaultPointProcessProxyFile));
-    m_poissonProcessProxy.reset(new PoissonProcessProxy(m_defaultPoissonProcessProxyFile));
+    if (m_defaultPointProcessProxyFile.length() > 0) {
+        std::cout << "m_pointProcessProxy != NULL" << std::endl;
+        m_pointProcessProxy.reset(new PointProcessProxy(m_defaultPointProcessProxyFile));
+        m_pointProcessProxy->parse();
+    }
+    if (m_defaultPoissonProcessProxyFile.length() > 0) {
+        std::cout << "m_poissonProcessProxy != NULL" << std::endl;
+        m_poissonProcessProxy.reset(new PoissonProcessProxy(m_defaultPoissonProcessProxyFile));
+        m_poissonProcessProxy->parse();
+    }
 
     m_userIDProxy->parse();
     m_objectIDProxy->parse();
     m_objectPreferenceProxy->parse();
     m_hourlyActionRateProxy->parse();
     m_typeDistributionProxy->parse();
-    m_pointProcessProxy->parse();
-    m_poissonProcessProxy->parse();
 
-    return;
-}
-
-StatisticProxy::~StatisticProxy() {
-    return;
+    initProxySourceFile();
 }
 
 vector<string>& StatisticProxy::getUserIDs() const {
@@ -69,10 +85,34 @@ void StatisticProxy::initProxySourceFile() {
     m_defaultUserIDProxyFile = socialcubePath + "/statistics/user_id.json";
     m_defaultObjectIDProxyFile = socialcubePath + "/statistics/obj_id.json";
     m_defaultHourlyActionRateProxyFile = socialcubePath + "/statistics/user_action_rate.json";
-    m_defaultObjectPreferenceProxyFile= socialcubePath + "/statistics/user_object_preference.json";
+    m_defaultObjectPreferenceProxyFile = socialcubePath + "/statistics/user_object_preference.json";
     m_defaultTypeDistributionProxyFile = socialcubePath + "/statistics/user_type_distribution.json";
-    m_defaultPointProcessProxyFile = socialcubePath + "/statistics/point_process.json";
-    m_defaultPoissonProcessProxyFile = socialcubePath + "/statistics/poisson_process.json";
+    m_defaultPointProcessProxyFile = "";
+    m_defaultPoissonProcessProxyFile = "";
+}
+
+void StatisticProxy::setUserIDProxyFilePath(std::string userIDProxyFilePath) {
+    m_defaultUserIDProxyFile = (getenv("SOCIALCUBEPATH")) + userIDProxyFilePath;
+}
+
+void StatisticProxy::setObjectIDProxyFilePath(std::string objectIDProxyFilePath) {
+    m_defaultObjectIDProxyFile = (getenv("SOCIALCUBEPATH")) + objectIDProxyFilePath;
+}
+
+void StatisticProxy::setHourlyActionRateProxyFilePath(std::string hourlyActionRateProxyFilePath) {
+    m_defaultHourlyActionRateProxyFile = (getenv("SOCIALCUBEPATH")) + hourlyActionRateProxyFilePath;
+}
+
+void StatisticProxy::setObjectPreferenceProxyFilePath(std::string objectPreferenceProxyFilePath) {
+    m_defaultObjectPreferenceProxyFile = (getenv("SOCIALCUBEPATH")) + objectPreferenceProxyFilePath;
+}
+
+void StatisticProxy::setPointProcessProxyFilePath(std::string pointProcessProxyFilePath) {
+    m_defaultPointProcessProxyFile = (getenv("SOCIALCUBEPATH")) + pointProcessProxyFilePath;
+}
+
+void StatisticProxy::setPoissonProcessProxyFilePath(std::string poissonProcessProxyFilePath) {
+    m_defaultPoissonProcessProxyFile = (getenv("SOCIALCUBEPATH")) + poissonProcessProxyFilePath;
 }
 
 uint64_t StatisticProxy::getUserCommunityTag(const std::string &userID) const {

--- a/src/StatisticProxy/StatisticProxy.cpp
+++ b/src/StatisticProxy/StatisticProxy.cpp
@@ -22,8 +22,6 @@ StatisticProxy::~StatisticProxy() {
 void StatisticProxy::startParsing() {
     std::cout << "m_defaultUserIDProxyFile = " << m_defaultUserIDProxyFile << std::endl;
     std::cout << "m_defaultObjectIDProxyFile = " << m_defaultObjectIDProxyFile << std::endl;
-    std::cout << "m_defaultPointProcessProxyFile = " << m_defaultPointProcessProxyFile << std::endl;
-    std::cout << "m_defaultPoissonProcessProxyFile = " << m_defaultPoissonProcessProxyFile << std::endl;
 
     m_userIDProxy.reset(new ClusteredUserIDProxy(m_defaultUserIDProxyFile));
     m_objectIDProxy.reset(new ObjectIDProxy(m_defaultObjectIDProxyFile));
@@ -31,12 +29,12 @@ void StatisticProxy::startParsing() {
     m_hourlyActionRateProxy.reset(new HourlyActionRateProxy(m_defaultHourlyActionRateProxyFile));
     m_typeDistributionProxy.reset(new TypeDistributionProxy(m_defaultTypeDistributionProxyFile));
     if (m_defaultPointProcessProxyFile.length() > 0) {
-        std::cout << "m_pointProcessProxy != NULL" << std::endl;
+        std::cout << "Using Point model, pointProcessProxyFile =" << m_defaultPointProcessProxyFile << std::endl;
         m_pointProcessProxy.reset(new PointProcessProxy(m_defaultPointProcessProxyFile));
         m_pointProcessProxy->parse();
     }
     if (m_defaultPoissonProcessProxyFile.length() > 0) {
-        std::cout << "m_poissonProcessProxy != NULL" << std::endl;
+        std::cout << "Using Poisson model, poissonProcessProxyFile =" << m_defaultPoissonProcessProxyFile << std::endl;
         m_poissonProcessProxy.reset(new PoissonProcessProxy(m_defaultPoissonProcessProxyFile));
         m_poissonProcessProxy->parse();
     }

--- a/src/StatisticProxy/StatisticProxy.hpp
+++ b/src/StatisticProxy/StatisticProxy.hpp
@@ -49,6 +49,15 @@ class StatisticProxy {
         
         static StatisticProxy& getInstance();
 
+        void startParsing();
+
+        void setUserIDProxyFilePath(std::string userIDProxyFilePath);
+        void setObjectIDProxyFilePath(std::string objectIDProxyFilePath);
+        void setHourlyActionRateProxyFilePath(std::string hourlyActionRateProxyFilePath);
+        void setObjectPreferenceProxyFilePath(std::string objectPreferenceProxyFilePath);
+        void setPointProcessProxyFilePath(std::string pointProcessProxyFilePath);
+        void setPoissonProcessProxyFilePath(std::string poissonProcessProxyFilePath);
+
         void retrieveStatistics();
 
         std::vector<std::string>& getUserIDs() const;

--- a/src/common/matOps.cpp
+++ b/src/common/matOps.cpp
@@ -1,7 +1,7 @@
 #include "matOps.hpp"
+#include <cmath>
 
 using namespace std;
-
 vector<double> matops::ones(int k) {
 	vector<double> v(k, 1.0);
 	return v;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4,6 +4,7 @@
 #include "Simulator/EventBasedSimulator.hpp"
 #include "Simulator/CacheAwareSimulator.hpp"
 #include "Agent/UserAgent/GithubAgent/SimpleGithubUserAgent.hpp"
+#include "Agent/ObjectAgent/ObjectAgent.hpp"
 #include "Agent/ObjectAgent/GithubAgent/SimpleGithubObjectAgent.hpp"
 #include "Agent/ObjectAgent/GithubAgent/PointProcessObjectAgent.hpp"
 #include "Agent/ObjectAgent/GithubAgent/PoissonProcessObjectAgent.hpp"
@@ -15,28 +16,91 @@ int main(int argc, const char* argv[]) {
 
     ArgParser args(argc, argv);
 
-    // Initialize Simulator
-    EventBasedSimulator s;
-    s.setStartTime(args.getSimulationStartTime());
-    s.setEndTime(args.getSimulationEndTime());
-    s.setUnitTime(args.getSimulationUnitTime());
+    /**
+     * Read config file
+     */
+    const string socialcubePath = (getenv("SOCIALCUBEPATH"));
 
-    // Initialize SimulatorProfiler
-    SimulatorProfiler& sp = SimulatorProfiler::getInstance();
-    sp.setProfileShow(args.getSimulationShowProfileStatus());
+    std::ifstream infile(socialcubePath + "/ProxyFilePaths.config");
+    std::string line;
+    std::string delimiter = "=";
 
-    // Initialize EventManager
-    EventManager& em = EventManager::getInstance();
-    em.setEventShow(args.getSimulationShowEventStatus());
-    em.setEventFileName(args.getSimulationEventFileName());
-    em.setEventBufferSize(args.getSimulationEventBufferSize());
+    std::string builderType;
 
-    // Initialize AgentBuilder
-    AgentBuilder<ClusteredGithubUserAgent, PointProcessObjectAgent> builder;
-    builder.build();
-    std::vector<std::shared_ptr<PointProcessObjectAgent>>& agentList = builder.getObjectAgentList();
-    for(auto& iter : agentList)
-        s.addUserAgent(iter.get());
+    std::map <std::string, std::string> filePaths;
 
-    s.simulate();
+    while (std::getline(infile, line)) {
+        std::cout << "line = " << line << std::endl;
+
+        if (line.length() > 0 && line.at(0) == '#') {
+            builderType = line.substr(line.find('#') + 1, line.length());
+            // Initialize AgentBuilder
+            std::cout << "builderType = " << builderType << std::endl;
+        } else if (line.length() > 0) {
+            int pos = line.find(delimiter);
+            if (pos != std::string::npos) {
+                std::string fileName = line.substr(0, pos);
+                std::string path = line.substr(pos + delimiter.length(), line.length());
+                std::cout << "fileName = " << fileName << ", path = " << path << ", length = " << filePaths.size() << std::endl;
+                filePaths.insert(std::pair <std::string, std::string> (fileName, path));
+            } else {
+                cout << "Format Error!" << endl;
+            }
+        }
+
+        if (line.length() == 0 or infile.peek() == EOF) {
+            // Initialize Simulator
+            EventBasedSimulator s;
+            s.setStartTime(args.getSimulationStartTime());
+            s.setEndTime(args.getSimulationEndTime());
+            s.setUnitTime(args.getSimulationUnitTime());
+
+            // Initialize SimulatorProfiler
+            SimulatorProfiler& sp = SimulatorProfiler::getInstance();
+            sp.setProfileShow(args.getSimulationShowProfileStatus());
+
+            // Initialize EventManager
+            EventManager& em = EventManager::getInstance();
+            em.setEventShow(args.getSimulationShowEventStatus());
+            em.setEventFileName(args.getSimulationEventFileName());
+            em.setEventBufferSize(args.getSimulationEventBufferSize());
+
+            if (builderType == "PointProcess") {
+                AgentBuilder<ClusteredGithubUserAgent, PointProcessObjectAgent> builder;
+                for (auto& iter : filePaths) {
+                    std::cout << iter.first << ": " << iter.second << std::endl;
+                    builder.setFilePath(iter.first, iter.second);
+                }
+                filePaths.clear();
+                std::vector<std::shared_ptr<PointProcessObjectAgent>> agentList;
+                builder.build();
+                agentList = builder.getObjectAgentList();
+                for(auto& iter : agentList)
+                    s.addUserAgent(iter.get());
+                s.simulate();
+            } else if (builderType == "PoissonProcess") {
+                AgentBuilder<ClusteredGithubUserAgent, PoissonProcessObjectAgent> builder;
+                for (auto& iter : filePaths)
+                    builder.setFilePath(iter.first, iter.second);
+                filePaths.clear();
+                std::vector<std::shared_ptr<PoissonProcessObjectAgent>> agentList;
+                builder.build();
+                agentList = builder.getObjectAgentList();
+                for(auto& iter : agentList)
+                    s.addUserAgent(iter.get());
+                s.simulate();
+            } else {
+                AgentBuilder<ClusteredGithubUserAgent, SimpleGithubObjectAgent> builder;
+                for (auto& iter : filePaths)
+                    builder.setFilePath(iter.first, iter.second);
+                filePaths.clear();
+                std::vector<std::shared_ptr<SimpleGithubObjectAgent>> agentList;
+                builder.build();
+                agentList = builder.getObjectAgentList();
+                for(auto& iter : agentList)
+                    s.addUserAgent(iter.get());
+                s.simulate();
+            }
+        }
+    }
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -30,18 +30,14 @@ int main(int argc, const char* argv[]) {
     std::map <std::string, std::string> filePaths;
 
     while (std::getline(infile, line)) {
-        std::cout << "line = " << line << std::endl;
-
         if (line.length() > 0 && line.at(0) == '#') {
             builderType = line.substr(line.find('#') + 1, line.length());
             // Initialize AgentBuilder
-            std::cout << "builderType = " << builderType << std::endl;
         } else if (line.length() > 0) {
             int pos = line.find(delimiter);
             if (pos != std::string::npos) {
                 std::string fileName = line.substr(0, pos);
                 std::string path = line.substr(pos + delimiter.length(), line.length());
-                std::cout << "fileName = " << fileName << ", path = " << path << ", length = " << filePaths.size() << std::endl;
                 filePaths.insert(std::pair <std::string, std::string> (fileName, path));
             } else {
                 cout << "Format Error!" << endl;
@@ -68,7 +64,6 @@ int main(int argc, const char* argv[]) {
             if (builderType == "PointProcess") {
                 AgentBuilder<ClusteredGithubUserAgent, PointProcessObjectAgent> builder;
                 for (auto& iter : filePaths) {
-                    std::cout << iter.first << ": " << iter.second << std::endl;
                     builder.setFilePath(iter.first, iter.second);
                 }
                 filePaths.clear();


### PR DESCRIPTION
Users now can run multiple models by specifying their types and corresponding proxy files in ProxyFilePaths.config.