### PR TITLE
Fixed event time format

### DIFF
--- a/src/common/Event.cpp
+++ b/src/common/Event.cpp
@@ -26,8 +26,8 @@ string Event::getEventType() const {
 
 string Event::getTimestampStr() const {
 
-    char buf[sizeof "1970-00-00T00:00:00Z"];
-    strftime(buf, sizeof buf, "%FT%TZ", gmtime(&m_timestamp));
+    char buf[sizeof "1970-00-00 00:00:00"];
+    strftime(buf, sizeof buf, "%F %T", gmtime(&m_timestamp));
     return buf;
 }
 


### PR DESCRIPTION
Fixed event time format to comply with PNNL metrics eval scripts requirements (no more 'T' or 'Z' but space)

@leowangx2013 I was maintaining this fix locally but since you are generating the simulated events on your end, you need to have this so I can use your results with PNNL metrics evaluation scripts.